### PR TITLE
[Iter1] Pull Request for Email Confirmation story

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,27 @@ rvm:
 sudo: false
 cache: bundler
 bundler_args: --without production
-before_install:
-  - export TZ=America/Los_Angeles
-  - gpg --passphrase $KEY -d -o config/application.yml config/application.yml.asc
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+    - CC_TEST_REPORTER_ID=$CC_KEY
+    - CC=./cc-test-reporter
+before_install:
+  - export TZ=America/Los_Angeles
+  - gpg --passphrase $KEY -d -o config/application.yml config/application.yml.asc
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - cp config/database.yml.test config/database.yml
   - mkdir -p public/stylesheets/venue && touch public/stylesheets/venue/default.css
   - bundle exec rake db:setup
-  - bundle exec rake ci:tests
+  - bundle exec rake spec
+  - $CC format-coverage --output coverage/codeclimate.$SUITE.json
+  # run Cucumber scenarios, and capture coverage
+  - bundle exec rake cucumber
+  - $CC format-coverage --output coverage/codeclimate.$SUITE.json
 after_script:
+  - $CC sum-coverage coverage/codeclimate.*.json | $CC upload-coverage
+  - $CC after-build --exit-code $TRAVIS_TEST_RESULT
   - rm -f config/application.yml

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,12 +131,13 @@ class ApplicationController < ActionController::Base
     addr = customer.email
     if customer.valid_email_address?
       begin
-        Mailer.send(method,*args).deliver_now
+        m = Mailer.send(method, *args).deliver_now
         flash[:notice] << " An email confirmation was sent to #{addr}.  If you don't receive it in a few minutes, please make sure 'audience1st.com' is on your trusted senders list, or the confirmation email may end up in your Junk Mail or Spam folder."
         Rails.logger.info("Confirmation email sent to #{addr}")
       rescue Exception => e
         flash[:notice] << " Your transaction was successful, but we couldn't "
         flash[:notice] << "send an email confirmation to #{addr}."
+        flash[:notice] << "The error message was: #{e.message}"
         Rails.logger.error("Emailing #{addr}: #{e.message} \n #{e.backtrace}")
       end
     else

--- a/app/controllers/vouchers_controller.rb
+++ b/app/controllers/vouchers_controller.rb
@@ -83,8 +83,7 @@ class VouchersController < ApplicationController
     if shouldEmail
       email_confirmation(:confirm_reservation, @customer, theshowdate, thenumtoadd)
     end
-    
-    redirect_to customer_path(@customer)
+    redirect_to customer_path(@customer, :notice => flash[:notice])
   end
 
   def update_comment

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -1,6 +1,6 @@
 class Mailer < ActionMailer::Base
 
-  helper :customers
+  helper :customers, :application
 
   default :from => "AutoConfirm-#{Option.venue_shortname}@audience1st.com"
   

--- a/app/views/customers/show.html.haml
+++ b/app/views/customers/show.html.haml
@@ -3,7 +3,7 @@
 
   %h1.page_heading.center #{@customer.full_name}'s #{@package_type} Reservations (#{humanize_season(season)})
   %br
-
+  
   %table#subscriptionReservations.full_width
     %thead
       %tr
@@ -42,7 +42,7 @@
         %th
         - if @gAdminDisplay
           %th.admin Comment
-    %tbody 
+    %tbody
       - VoucherPresenter.groups_from_vouchers(@other_vouchers, include_all_showdates).each do |group|
         %tr[group.vouchers.first]
           - if group.reserved

--- a/app/views/mailer/confirm_reservation.text.erb
+++ b/app/views/mailer/confirm_reservation.text.erb
@@ -11,8 +11,8 @@ We're confirming your reservation for the following performance:
 
 <%= word_wrap(@notes, :line_width => 60) unless @notes.blank? %>
 
-<%= word_wrap(strip_tags( sanitize_option_text(:general_confirmation_email_notes, :spanify=> false)), :line_width => 60) %>
+<%= word_wrap(strip_tags( sanitize_option_text(:general_confirmation_email_notes, :div, :spanify => false)), :line_width => 60) %>
 
-<%= word_wrap(strip_tags(sanitize_option_text((@customer.subscriber ? :subscriber_confirmation_email_notes :  :nonsubscriber_confirmation_email_notes), :spanify => false)), :line_width => 60) %>
+<%= word_wrap(strip_tags(sanitize_option_text((@customer.subscriber? ? :subscriber_confirmation_email_notes :  :nonsubscriber_confirmation_email_notes), :div, :spanify => false)), :line_width => 60) %>
 
 <%= render 'contact_us' %>

--- a/app/views/vouchers/new.html.haml
+++ b/app/views/vouchers/new.html.haml
@@ -13,9 +13,14 @@
   %label{:for => 'comments'}  Optional comments:
   = text_area_tag 'comments', '', {:size => '40x2'}
   %br
-
+  
   #reserve_for= render :partial => 'reserve_for'
+  %br
     
+  %label  Send Email Confirmation:
+  = check_box_tag 'customer_email', 1, false, :disabled => @email_disabled
+  %br
+  
   = submit_tag "Add Vouchers"
 
   = link_to  "Cancel", customer_path(@customer), :class => 'genButton'

--- a/features/reservations/add_comps.feature
+++ b/features/reservations/add_comps.feature
@@ -13,13 +13,13 @@ Background: logged in as admin and shows are available
 Scenario Outline: add comps to performance
 
   Given it is currently <time>
-  When I visit the add comps page for customer "Tom Foolery"
+  When I visit the add comps page for customer "Armando Fox"
   When I select "Comp (2010)" from "What type:"
   And  I fill in "How many:" with "<number>"
   And  I select "Macbeth - Tuesday, Apr 20, 8:00 PM (2 left)" from "Reserve for:"
   And  I fill in "Optional comments:" with "Courtesy Comp"
   And  I press "Add Vouchers"
-  Then customer "Tom Foolery" should have an order with comment "Courtesy Comp" containing the following tickets:
+  Then customer "Armando Fox" should have an order with comment "Courtesy Comp" containing the following tickets:
   | qty      | type | showdate       |
   | <number> | Comp | Apr 20, 8:00pm |
 
@@ -31,5 +31,35 @@ Scenario Outline: add comps to performance
   | Apr 18, 2010         |      4 |
   | Apr 20, 2010, 8:15pm |      4 |
 
+
+Scenario: email should be sent if customer_email is checked
+
+  Given it is currently Apr 20, 2010, 8:15pm
+  Given customer "Armando Fox" has email "armandoisafox@email.com" and password "pa$$w0rd"
+  When I visit the add comps page for customer "Armando Fox"
+  When I select "Comp (2010)" from "What type:"
+  And  I fill in "How many:" with "2"
+  And  I select "Macbeth - Tuesday, Apr 20, 8:00 PM (2 left)" from "Reserve for:"
+  And  I fill in "Optional comments:" with "Courtesy Comp"
+  And I check "customer_email"
+  And  I press "Add Vouchers"
+  And an email should be sent to customer "Armando Fox"
   
-  
+Scenario: email should not be sent if customer_email is unchecked
+
+  Given it is currently Apr 20, 2010, 8:15pm
+  Given customer "Armando Fox" has email "armandoisafox@email.com" and password "pa$$w0rd"
+  When I visit the add comps page for customer "Armando Fox"
+  When I select "Comp (2010)" from "What type:"
+  And  I fill in "How many:" with "2"
+  And  I select "Macbeth - Tuesday, Apr 20, 8:00 PM (2 left)" from "Reserve for:"
+  And  I fill in "Optional comments:" with "Courtesy Comp"
+  And I uncheck "customer_email"
+  And  I press "Add Vouchers"
+  And no email should be sent to customer "Armando Fox"
+
+Scenario: checkbox unavailable if no email
+
+  Given it is currently Apr 20, 2010, 8:15pm
+  When I visit the add comps page for customer "NoEmail Customer"
+  Then the "customer_email" checkbox should be disabled

--- a/features/reservations/staff_comment_on_reservation.feature
+++ b/features/reservations/staff_comment_on_reservation.feature
@@ -19,7 +19,7 @@ Scenario: add comment to revenue reservation
   And I fill in "comments" with "Will be late" within "#voucher_1"
   And I press "Save" within "#voucher_1"
   And I visit the home page for customer "Tom Foolery"
-  Then the "comments" field within "#voucher_1" should contain "Will be late" 
+  Then the "comments" field within "#voucher_1" should contain "Will be late"
 
 Scenario: add comment to subscriber reservation
 
@@ -31,5 +31,5 @@ Scenario: add comment to subscriber reservation
   And I fill in "comments" with "Will be late" within "#voucher_1"
   And I press "Save" within "#voucher_1"
   And I visit the home page for customer "Tom Foolery"
-  Then the "comments" field within "#voucher_1" should contain "Will be late" 
+  Then the "comments" field within "#voucher_1" should contain "Will be late"
     

--- a/features/step_definitions/customer_steps.rb
+++ b/features/step_definitions/customer_steps.rb
@@ -106,7 +106,7 @@ end
 
 Given /^customer "(.*) (.*)" has email "(.*)" and password "(.*)"$/ do |first,last,email,pass|
   c = find_or_create_customer first,last
-  c.update_attributes!(:email => email, :password => pass)
+  c.update_attributes!(:email => email, :password => pass, :password_confirmation => pass)
 end
 
 Given /^customer "(.*) (.*)" (should have|has) secret question "(.*)" with answer "(.*)"$/ do |first,last,assert,question,answer|


### PR DESCRIPTION
This PR is for the Email Conf story from Iter1

Warning: I needed to make two additional changes for the cherry-pick to pass the tests and work in dev. I'm not sure why this was the case, as our current rails4 didn't need these changes to work (as can be seen from our rails4 branch working on staging). With these changes, this branch still works exactly the same as it does in staging and passes all tests but you may want to pay special attention to these two lines when reviewing the changes.

The lines in question are 

vouchers_controller 86: 
  redirect_to customer_path(@customer)
to
  redirect_to customer_path(@customer, :notice => flash[:notice])

and 

mailer.rb 1:
  helper :customers
to
  helper :customers, :application