### PR TITLE
Cs169/remove extraneous gift recipient info clean

### DIFF
--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -300,7 +300,7 @@ class StoreController < ApplicationController
     recipient = recipient_from_params
     matching =  recipient[1]
     if matching == "found_matching_customer"
-        flash.now[:notice] = I18n.t('store.gift_recipient_on_file')  
+        flash[:notice] = I18n.t('store.gift_recipient_on_file')  
     end
     redirect_to checkout_path(@customer, checkout_params)
     true

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -213,9 +213,6 @@ class StoreController < ApplicationController
 
   def checkout
     redirect_to store_path, :alert => t('store.errors.empty_order') if @cart.cart_empty?
-    if params[:matching] == "found_matching_customer"
-        flash.now[:notice] = I18n.t('store.gift_recipient_on_file')  
-    end
     @page_title = "Review Order For #{@customer.full_name}"
     @sales_final_acknowledged = @is_admin || (params[:sales_final].to_i > 0)
     @checkout_message = (@cart.includes_regular_vouchers? ? Option.precheckout_popup : '')
@@ -302,7 +299,9 @@ class StoreController < ApplicationController
     checkout_params[:email_confirmation] = true if params[:email_confirmation]
     recipient = recipient_from_params
     matching =  recipient[1]
-    checkout_params[:matching] = matching 
+    if matching == "found_matching_customer"
+        flash.now[:notice] = I18n.t('store.gift_recipient_on_file')  
+    end
     redirect_to checkout_path(@customer, checkout_params)
     true
   end

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -297,8 +297,7 @@ class StoreController < ApplicationController
     checkout_params = {}
     checkout_params[:sales_final] = true if params[:sales_final]
     checkout_params[:email_confirmation] = true if params[:email_confirmation]
-    recipient = recipient_from_params
-    matching =  recipient[1]
+    matching = recipient_from_params[1]
     if matching == "found_matching_customer"
         flash[:notice] = I18n.t('store.gift_recipient_on_file')  
     end

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -180,7 +180,6 @@ class StoreController < ApplicationController
   def shipping_address
     @mailable = @cart.includes_mailable_items?
     @recipient ||= Customer.new and return if request.get?
-    
     # request is a POST: collect shipping address
     # record whether we should mail to purchaser or recipient
     @cart.ship_to_purchaser = params[:ship_to_purchaser] if params[:mailable_gift_order]
@@ -189,10 +188,9 @@ class StoreController < ApplicationController
     #  the buyer needs to modify it, great.
     #  Otherwise... create a NEW record based
     #  on the gift receipient information provided.
-    #byebug
     recipient = recipient_from_params
     @recipient, matching =  recipient[0], recipient[1]
-	session[:matching] = (matching == "found_matching_customer") ? true : false
+    session[:matching] = (matching == "found_matching_customer") ? true : false
     if @recipient.email == @customer.email
         flash.now[:alert] = I18n.t('store.errors.gift_diff_email_notice') 
         render :action => :shipping_address

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -189,8 +189,10 @@ class StoreController < ApplicationController
     #  the buyer needs to modify it, great.
     #  Otherwise... create a NEW record based
     #  on the gift receipient information provided.
+    #byebug
     recipient = recipient_from_params
     @recipient, matching =  recipient[0], recipient[1]
+	session[:matching] = (matching == "found_matching_customer") ? true : false
     if @recipient.email == @customer.email
         flash.now[:alert] = I18n.t('store.errors.gift_diff_email_notice') 
         render :action => :shipping_address
@@ -204,16 +206,8 @@ class StoreController < ApplicationController
       return
     end
     @recipient.created_by_admin = @is_admin if @recipient.new_record?
-    
-    if matching == "found_matching_customer"
-        @recipient.matching = true
-    else
-        @recipient.matching = false     
-    end
     @recipient.save!
     @cart.customer = @recipient
-   
- 
     @cart.save!
     redirect_to_checkout
   end
@@ -222,7 +216,7 @@ class StoreController < ApplicationController
 
   def checkout
     redirect_to store_path, :alert => t('store.errors.empty_order') if @cart.cart_empty?
-    if @cart.customer.matching
+    if session[:matching]
         flash.now[:notice] = I18n.t('store.gift_recipient_on_file')  
     end
     @page_title = "Review Order For #{@customer.full_name}"

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -179,8 +179,8 @@ class StoreController < ApplicationController
 
   def shipping_address
     @mailable = @cart.includes_mailable_items?
-    @recipient ||= (@cart.customer || Customer.new) and return if request.get?
-
+    @recipient ||= Customer.new and return if request.get?
+    
     # request is a POST: collect shipping address
     # record whether we should mail to purchaser or recipient
     @cart.ship_to_purchaser = params[:ship_to_purchaser] if params[:mailable_gift_order]

--- a/app/views/customers/_gift_recipient_info.html.haml
+++ b/app/views/customers/_gift_recipient_info.html.haml
@@ -1,0 +1,17 @@
+- disabled = defined?(passive) && passive
+%fieldset.billing_info
+  %legend= local_assigns[:legend] || 'Address'
+  %p.text-center.bg-secondary.text-light  Fields <span class="strong">like this</span> are required.
+  = fields_for customer, :namespace => (disabled ? 'gift' : '') do |f|
+    .form-row
+      .form-group.col-md-4
+        %label.col-form-label.strong{:for => 'customer_first_name'} First name
+        = f.text_field :first_name, :size => 16, :maxlength => 40, :readonly => disabled, :class => 'form-control form-control-sm'
+      .form-group.col-md-4
+        %label.col-form-label.strong{:for => 'customer_last_name'} Last name
+        = f.text_field :last_name, :size => 16, :maxlength => 40, :readonly => disabled, :class => 'form-control form-control-sm'
+      .form-row
+      .form-group.col-md-6
+        %label.col-form-label.strong{:for=>:customer_email} Email
+        = f.text_field :email, {:size => 30, :type => :email, :maxlength => 40, :readonly => disabled, :class => 'form-control form-control-sm' }
+

--- a/app/views/store/checkout.html.haml
+++ b/app/views/store/checkout.html.haml
@@ -7,7 +7,7 @@
   - if @cart.gift?
     #gift_recipient
       %h2 This Order is a Gift For...
-      = render :partial => 'customers/billing_address', :locals => {:customer => @cart.customer, :passive => true, :legend => 'Gift Recipient Info' }
+      = render :partial => 'customers/gift_recipient_info', :locals => {:customer => @cart.customer, :passive => true, :legend => 'Gift Recipient Info' }
 
   = form_tag place_order_path(@cart.purchaser), :id => '_stripe_payment_form' do
 

--- a/app/views/store/place_order.html.haml
+++ b/app/views/store/place_order.html.haml
@@ -20,9 +20,6 @@
           %legend This order is a gift for:
           %label= @recipient.full_name
           %br
-          %label= @recipient.street
-          %br
-          %label= "#{h @recipient.city}, #{h @recipient.state} #{h @recipient.zip}"
         %p.alert.alert-warning Note: Recipient has NOT been notified of this gift.
 
     = render :partial => 'cart', :object => @order

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,8 @@ en:
 
     accept_terms_of_sale: >
       By completing your order, you agree to the <a href="#" onclick="alert('%{terms_of_sale_text}')">terms of sale</a>.
+    gift_recipient_on_file: >
+      We have the gift recipient's address and phone number on file.
 
     errors:
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190401004004) do
+ActiveRecord::Schema.define(version: 20190417013019) do
 
   create_table "account_codes", force: :cascade do |t|
     t.string "name",            limit: 40,  default: "", null: false
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20190401004004) do
     t.date     "birthday"
     t.string   "token"
     t.datetime "token_created_at"
+    t.boolean  "matching"
   end
 
   add_index "customers", ["city"], name: "index_customers_on_city"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190417013019) do
+ActiveRecord::Schema.define(version: 20190401004004) do
 
   create_table "account_codes", force: :cascade do |t|
     t.string "name",            limit: 40,  default: "", null: false
@@ -62,7 +62,6 @@ ActiveRecord::Schema.define(version: 20190417013019) do
     t.date     "birthday"
     t.string   "token"
     t.datetime "token_created_at"
-    t.boolean  "matching"
   end
 
   add_index "customers", ["city"], name: "index_customers_on_city"

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -130,6 +130,14 @@ Then /^(?:|I )should not see \/([^\/]*)\/(?: within "([^\"]*)")?$/ do |regexp, s
   end
 end
 
+# Created test
+Then /^(?:|I )should not see the following: "([^\"]*)"$/ do |textlist|
+    textlist.split(', ').each do |text|
+      step "I should not see \"#{text}\""
+    end
+end
+
+
 Then /^the "([^\"]*)" field(?: within "([^\"]*)")? should (contain|equal) "([^\"]*)"$/ do |field, selector, equality_check, value|
   with_scope(selector) do
     val = find_field(field).value

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -137,7 +137,6 @@ Then /^(?:|I )should not see the following: "([^\"]*)"$/ do |textlist|
     end
 end
 
-
 Then /^the "([^\"]*)" field(?: within "([^\"]*)")? should (contain|equal) "([^\"]*)"$/ do |field, selector, equality_check, value|
   with_scope(selector) do
     val = find_field(field).value

--- a/features/store/add_tickets_to_cart.feature
+++ b/features/store/add_tickets_to_cart.feature
@@ -29,6 +29,4 @@ Scenario: Add regular tickets to my order with a donation
   Then I should be on the Checkout page
   And the cart total price should be $47.00
   And the cart should contain 2 "General" tickets for "October 1, 2010, 7:00pm"
-  And the cart should contain a donation of $17.00 to "General Fund"
-
-  
+  And the cart should contain a donation of $17.00 to "General Fund"  

--- a/features/store/gift.feature
+++ b/features/store/gift.feature
@@ -36,8 +36,4 @@ Scenario: Confidential information is removed, street address, phone number
   Given I go to the shipping info page for customer "Tom Foolery"
   When I fill in the ".billing_info" fields with "John Lennon, Imagine St., Berk, CA 99999, 123-456-7890, john@lennon.com"
   And I proceed to checkout
-  Then I should not see "123-456-7890"
-  And I should not see "Imagine St."
-  And I should not see "Berk"
-  And I should not see "CA"
-  And I should not see "99999"
+  Then I should not see the following: "123-456-7890, Imagine St., Berk, CA, 99999"

--- a/features/store/gift.feature
+++ b/features/store/gift.feature
@@ -10,8 +10,11 @@ Background:
   And my gift order contains the following tickets:
     | show    | qty | type    | price | showdate             |
     | Chicago |   2 | General |  7.00 | May 15, 2010, 8:00pm |
+  And the following customers exist:
+    | first_name | last_name | email           | created_by_admin | street        | password | password_confirmation | city | state |   zip | last_login          | updated_at | 
+    | John       | Lennon    | john@lennon.com | false            | Imagine St.   | imagine  | imagine               | Berk | CA    | 99999 | 2009-01-01          | 2009-01-01 |  
   And I go to the store page
-  
+ 
 Scenario: Allow gift purchase if logged in and approved by box office manager
   Given the setting "allow gift tickets" is "true"
   And I go to the store page
@@ -28,3 +31,13 @@ Scenario: customer gifting to oneself should be unsuccessful
   And I proceed to checkout
   Then I should be on the shipping info page
   And I should see "Please enter a gift recipient email different from your own."
+    
+Scenario: Confidential information is removed, street address, phone number
+  Given I go to the shipping info page for customer "Tom Foolery"
+  When I fill in the ".billing_info" fields with "John Lennon, Imagine St., Berk, CA 99999, 123-456-7890, john@lennon.com"
+  And I proceed to checkout
+  Then I should not see "123-456-7890"
+  And I should not see "Imagine St."
+  And I should not see "Berk"
+  And I should not see "CA"
+  And I should not see "99999"

--- a/features/store/gift.feature
+++ b/features/store/gift.feature
@@ -37,4 +37,6 @@ Scenario: Confidential information is removed, street address, phone number
   And I proceed to checkout
   Then I should not see the following: "123-456-7890, Imagine St., Berk, CA, 99999"
   And I should see "We have the gift recipient's address and phone number on file."
-
+  When I place my order with a valid credit card
+  Then I should be on the order confirmation page
+  And I should not see the following: "123-456-7890, Imagine St., Berk, CA, 99999"

--- a/features/store/gift.feature
+++ b/features/store/gift.feature
@@ -11,8 +11,8 @@ Background:
     | show    | qty | type    | price | showdate             |
     | Chicago |   2 | General |  7.00 | May 15, 2010, 8:00pm |
   And the following customers exist:
-    | first_name | last_name | email           | created_by_admin | street        | password | password_confirmation | city | state |   zip | last_login          | updated_at | 
-    | John       | Lennon    | john@lennon.com | false            | Imagine St.   | imagine  | imagine               | Berk | CA    | 99999 | 2009-01-01          | 2009-01-01 |  
+    | first_name | last_name | email           | created_by_admin | street        | password | password_confirmation | city     | state |   zip | last_login          | updated_at | 
+    | John       | Lennon    | john@lennon.com | false            | Imagine St.   | imagine  | imagine               | Berkeley | CA    | 99999 | 2009-01-01          | 2009-01-01 |  
  
 Scenario: Allow gift purchase if logged in and approved by box office manager
   Given the setting "allow gift tickets" is "true"
@@ -33,10 +33,10 @@ Scenario: customer gifting to oneself should be unsuccessful
     
 Scenario: Confidential information is removed, street address, phone number
   Given I go to the shipping info page for customer "Tom Foolery"
-  When I fill in the ".billing_info" fields with "John Lennon, Imagine St., Berk, CA 99999, 123-456-7890, john@lennon.com"
+  When I fill in the ".billing_info" fields with "John Lennon, Imagine St., Berkeley, CA 99999, 123-456-7890, john@lennon.com"
   And I proceed to checkout
-  Then I should not see the following: "123-456-7890, Imagine St., Berk, CA, 99999"
+  Then I should not see the following: "123-456-7890, Imagine St., Berkeley, CA, 99999"
   And I should see "We have the gift recipient's address and phone number on file."
   When I place my order with a valid credit card
   Then I should be on the order confirmation page
-  And I should not see the following: "123-456-7890, Imagine St., Berk, CA, 99999"
+  And I should not see the following: "123-456-7890, Imagine St., Berkeley, CA, 99999"

--- a/features/store/gift.feature
+++ b/features/store/gift.feature
@@ -13,7 +13,6 @@ Background:
   And the following customers exist:
     | first_name | last_name | email           | created_by_admin | street        | password | password_confirmation | city | state |   zip | last_login          | updated_at | 
     | John       | Lennon    | john@lennon.com | false            | Imagine St.   | imagine  | imagine               | Berk | CA    | 99999 | 2009-01-01          | 2009-01-01 |  
-  And I go to the store page
  
 Scenario: Allow gift purchase if logged in and approved by box office manager
   Given the setting "allow gift tickets" is "true"
@@ -37,3 +36,5 @@ Scenario: Confidential information is removed, street address, phone number
   When I fill in the ".billing_info" fields with "John Lennon, Imagine St., Berk, CA 99999, 123-456-7890, john@lennon.com"
   And I proceed to checkout
   Then I should not see the following: "123-456-7890, Imagine St., Berk, CA, 99999"
+  And I should see "We have the gift recipient's address and phone number on file."
+


### PR DESCRIPTION
Feature: Removed confidential information (i.e. Address, phone number) from being shown after submitting shipping information for a gift purchase.

- Added Flash error messages for already existing customers.
- Added another step definition to web_steps.rb
- Added more scenarios to gift.feature.