### PR TITLE
Cs169/name email match address differs

### DIFF
--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -195,6 +195,7 @@ class StoreController < ApplicationController
         render :action => :shipping_address
         return
     end 
+
     # make sure minimal info for gift receipient was specified.
     @recipient.gift_recipient_only = true
     unless @recipient.valid?
@@ -287,7 +288,10 @@ class StoreController < ApplicationController
     recipient = Customer.find_unique(try_customer)
     (recipient && recipient.valid_as_gift_recipient?) ? [recipient,"found_matching_customer"] : [try_customer, "new_customer"]
   end
-
+  def email_last_name_match_diff_address?
+    try_customer = Customer.new(params[:customer])
+    Customer.email_last_name_match_diff_address?(try_customer)
+  end
   def remember_cart_in_session!
     @cart.save!
     session[:cart] = @cart.id
@@ -298,6 +302,9 @@ class StoreController < ApplicationController
     checkout_params[:sales_final] = true if params[:sales_final]
     checkout_params[:email_confirmation] = true if params[:email_confirmation]
     matching = recipient_from_params[1]
+    byebug 
+    #if email_last_name_match_diff_address?
+    #    flash[:notice] = I18n.t('store.gift_matching_email_last_name_diff_address')
     if matching == "found_matching_customer"
         flash[:notice] = I18n.t('store.gift_recipient_on_file')  
     end

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -302,10 +302,9 @@ class StoreController < ApplicationController
     checkout_params[:sales_final] = true if params[:sales_final]
     checkout_params[:email_confirmation] = true if params[:email_confirmation]
     matching = recipient_from_params[1]
-    byebug 
-    #if email_last_name_match_diff_address?
-    #    flash[:notice] = I18n.t('store.gift_matching_email_last_name_diff_address')
-    if matching == "found_matching_customer"
+    if email_last_name_match_diff_address?
+        flash[:notice] = I18n.t('store.gift_matching_email_last_name_diff_address')
+    elsif matching == "found_matching_customer"
         flash[:notice] = I18n.t('store.gift_recipient_on_file')  
     end
     redirect_to checkout_path(@customer, checkout_params)

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -195,7 +195,6 @@ class StoreController < ApplicationController
       render :action => :shipping_address
       return
     end 
-
     # make sure minimal info for gift receipient was specified.
     @recipient.gift_recipient_only = true
     unless @recipient.valid?

--- a/app/models/customer/search.rb
+++ b/app/models/customer/search.rb
@@ -29,6 +29,18 @@ class Customer < ActiveRecord::Base
     possible_dups = Customer.find_by_sql(sql)
   end
 
+  # account for case where email and last name match
+  # but mailing address does not
+  
+  def self.email_last_name_match_diff_address?(p)
+    email, last_name, street = p.email, p.last_name, p.street
+    # email can't match different last name if either is blank
+    return false if (email.blank? || last_name.blank? || street.blank?)
+    recipient = Customer.where('email LIKE ? AND last_name LIKE ?', email.strip, last_name.strip).first
+    # otherwise, we have a matching email, so check if last name is diff
+    return (!recipient.nil?  &&  street != recipient.street)   
+  end
+  
   # given some customer info, find this customer in the database with
   # high confidence;  if not found or ambiguous, return nil
 

--- a/app/models/customer/search.rb
+++ b/app/models/customer/search.rb
@@ -34,10 +34,10 @@ class Customer < ActiveRecord::Base
   
   def self.email_last_name_match_diff_address?(p)
     email, last_name, street = p.email, p.last_name, p.street
-    # email can't match different last name if either is blank
+    # email, last_name can't match different address if any are blank
     return false if (email.blank? || last_name.blank? || street.blank?)
     recipient = Customer.where('email LIKE ? AND last_name LIKE ?', email.strip, last_name.strip).first
-    # otherwise, we have a matching email, so check if last name is diff
+    # otherwise, we have a matching email, so check if address is diff
     return (!recipient.nil?  &&  street != recipient.street)   
   end
   

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,8 +97,12 @@ en:
 
     accept_terms_of_sale: >
       By completing your order, you agree to the <a href="#" onclick="alert('%{terms_of_sale_text}')">terms of sale</a>.
+    
     gift_recipient_on_file: >
       We have the gift recipient's address and phone number on file.
+    
+    gift_matching_email_last_name_diff_address: >
+      We recognize that name and email address, but we have a different mailing address and/or phone number on file for this person.  Please note that we will use our contact information to contact them.  If you believe this is a problem, please contact the box office after completing this gift order.
 
     errors:
 

--- a/features/step_definitions/web_custom_steps.rb
+++ b/features/step_definitions/web_custom_steps.rb
@@ -130,3 +130,9 @@ When /^I fill in the "(.*)" fields as follows:$/ do |fieldset, table|
   end
 end
 
+# Lets you write step def such as:
+# Then I should see the message for "customers.confirm_delete"
+Then /I should see the message for "(.*)"/ do |i18n_key|
+  message = I18n.translate!(i18n_key)
+  page.should have_content(message)
+end

--- a/features/store/gift.feature
+++ b/features/store/gift.feature
@@ -40,3 +40,10 @@ Scenario: Confidential information is removed, street address, phone number
   When I place my order with a valid credit card
   Then I should be on the order confirmation page
   And I should not see the following: "123-456-7890, Imagine St., Berkeley, CA, 99999"
+
+Scenario: notify customer if gift recipient's mailing address does not match but email and last name does
+  Given I go to the shipping info page for customer "Tom Foolery"
+  When I fill in the ".billing_info" fields with "Bob Lennon, Belief St., Berkeley, CA 99999, 510-999-9999, john@lennon.com"
+  And I proceed to checkout
+  Then I should be on the checkout page
+  And I should see the message for "store.gift_matching_email_last_name_diff_address"

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -161,7 +161,6 @@ describe Customer do
         @old = create(:customer,@attrs)
         @cust = Customer.new(@attrs)
       end
-
       it "returns false if address does match" do
           Customer.email_last_name_match_diff_address?(@old).should be_falsy
       end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -150,7 +150,27 @@ describe Customer do
       end
     end
   end
-  
+  describe "determine if mailing address does not match record" do
+    context "when email and last name matches" do
+      before(:each) do
+        @attrs = {:first_name => 'Bob', :last_name => 'Jones',
+          :email => 'bobjones@mail.com',
+          :street => '1234 Fake St',
+          :city => 'New York', :state => 'NY', :zip => '99999'
+        }
+        @old = create(:customer,@attrs)
+        @cust = Customer.new(@attrs)
+      end
+
+      it "returns false if address does match" do
+          Customer.email_last_name_match_diff_address?(@old).should be_falsy
+      end
+      it "returns true if address doesn't match" do
+          @cust.street = "1234 Genuine St"
+          Customer.email_last_name_match_diff_address?(@cust).should be_truthy
+      end
+    end
+  end
   describe "find unique" do
     def names_match(a,b)
       our_first,our_last = a.split(/ +/)


### PR DESCRIPTION
Passing build: https://travis-ci.org/raisindoc/audience1st/builds/526111448 

Note: the check for whether mailing address differs only checks to see if street is different (not City, State or Zipcode) as is consistent with Customer.match_first_last_and_address. Let me know if you want me to check for City, State and Zipcode (or a mix of) in order to determine if address matches. 