### PR TITLE
All subscribers show error if no selection

### DIFF
--- a/app/models/reports/all_subscribers.rb
+++ b/app/models/reports/all_subscribers.rb
@@ -9,12 +9,9 @@ class AllSubscribers < Report
   end
 
   def generate(params = {})
+    add_error("Please specify one or more subscriber voucher types.") and return if (vouchertypes = params[:vouchertypes]).blank?
     vouchertypes = Report.list_of_ints_from_multiselect(params[:vouchertypes])
-    @relation = 
-      if vouchertypes.empty? 
-      then Customer.purchased_any_vouchertypes(Vouchertype.subscription_vouchertypes.map(&:id))
-      else Customer.purchased_any_vouchertypes(vouchertypes) 
-      end
+    @relation = Customer.purchased_any_vouchertypes(vouchertypes) 
   end
 end
 

--- a/features/reports/browse_customer_reports.feature
+++ b/features/reports/browse_customer_reports.feature
@@ -25,4 +25,5 @@ Scenario Outline: browse reports
     | Subscriber open vouchers            | Please specify one or more subscriber voucher types |
     | Attendance by show                  | Please specify one or more productions              |
     | Donor appeal                        | 0 matches                                           |
+    | All subscribers                     | Please specify one or more subscriber voucher types |
 


### PR DESCRIPTION
Based on the feedback from the last iteration, now under the reports page it should do the following:
- pop an alert when no entry (or no subscription voucher type) is selected.

https://tranquil-thicket-52105.herokuapp.com
Steps for this feature:
- Navigate to the reports page (https://tranquil-thicket-52105.herokuapp.com/reports)
- Select "All Subscriptions" report
- Click "Run Report" without selecting any subscription