### PR TITLE
Sales report can be downloaded as .csv

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -60,7 +60,7 @@ class ReportsController < ApplicationController
   end
 
   def advanced_details
-    if params[:commit] == 'View'
+    if params[:commit] == 'Display on Screen'
       redirect_to advance_sales_reports_path(params)
       return
     end
@@ -106,7 +106,7 @@ class ReportsController < ApplicationController
         end
       end
     end
-    
+
     y = (params[:id] || Time.current.year).to_i
     download_to_excel(output, "advanced_details#{y}")
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -61,7 +61,7 @@ class ReportsController < ApplicationController
 
   def advanced_details
     if params[:commit] == 'View'
-      redirect_to advance_sales_reports_path, :shows => params[:shows]
+      redirect_to advance_sales_reports_path(params)
       return
     end
     # TODO: fix revenue info

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -19,12 +19,8 @@ class ReportsController < ApplicationController
 
   def advance_sales
     show_ids = params[:shows]
-    download = params[:download]
     redirect_to(reports_path, :alert => "Please select one or more shows.") if show_ids.blank?
     @shows = Show.where(:id => show_ids).includes(:showdates => :vouchers)
-    if (download == true)
-      redirect_to(advanced_details_reports_path, :shows => params[:shows])
-    end
   end
 
   def showdate_sales
@@ -64,10 +60,12 @@ class ReportsController < ApplicationController
   end
 
   def advanced_details
-    if params[:commit] == 'Go'
+    if params[:commit] == 'View'
       redirect_to advance_sales_reports_path, :shows => params[:shows]
       return
     end
+    # TODO: fix revenue info
+    # TODO: when multiple shows are selected at the same time
     # entity = Object.const_get(params[:klass])
     # entity = entity.find(params[:id])
     # vouchers = entity.vouchers.finalized
@@ -77,13 +75,7 @@ class ReportsController < ApplicationController
     show_ids = params[:shows]
     show = Show.where(:id => show_ids).includes(:showdates => :vouchers).first
 
-
-    puts "blah0"
-    puts show_ids
-
     output = CSV.generate do |csv|
-      puts "blah1"
-      puts show.showdates
       csv << %w[Show\ Name
                 Run\ Dates
                 Show\ Date

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -24,9 +24,9 @@ class Show < ActiveRecord::Base
   # current_or_next returns the Show object corresponding to either the
   # currently running show, or the one with the next soonest opening date.
 
-  def self.current_or_next
-    Showdate.current_or_next.try(:show)
-  end
+  # def self.current_or_next
+  #   Showdate.current_or_next.try(:show)
+  # end
 
   scope :current_and_future, -> {
     joins(:showdates).
@@ -171,5 +171,5 @@ class Show < ActiveRecord::Base
     self.closing_date = last if closing_date < last
     return self.changed?
   end
-      
+
 end

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -24,9 +24,9 @@ class Show < ActiveRecord::Base
   # current_or_next returns the Show object corresponding to either the
   # currently running show, or the one with the next soonest opening date.
 
-  # def self.current_or_next
-  #   Showdate.current_or_next.try(:show)
-  # end
+  def self.current_or_next
+    Showdate.current_or_next.try(:show)
+  end
 
   scope :current_and_future, -> {
     joins(:showdates).

--- a/app/models/showdate.rb
+++ b/app/models/showdate.rb
@@ -34,6 +34,7 @@ class Showdate < ActiveRecord::Base
   validates_length_of :description, :maximum => 32, :allow_nil => true
   
   attr_accessible :thedate, :end_advance_sales, :max_advance_sales, :description, :show_id, :seatmap_id
+  attr_accessible :valid_vouchers
 
   require_dependency 'showdate/sales_reporting'
   require_dependency 'showdate/menu_descriptions'
@@ -51,6 +52,7 @@ class Showdate < ActiveRecord::Base
 
   scope :general_admission, -> { where(:seatmap_id => nil) }
   scope :reserved_seating,  -> { where.not(:seatmap_id => nil) }
+  scope :blah, -> { joins(:valid_vouchers) }
 
   private
 

--- a/app/models/vouchertype.rb
+++ b/app/models/vouchertype.rb
@@ -44,6 +44,9 @@ class Vouchertype < ActiveRecord::Base
 
   protected
 
+  def find_valid_voucher
+    self.valid_vouchers.fin
+  end
   # for bundle vouchers, the included_vouchers values should be ints
   # and the keys (id's) should be strings, eg {"3" => 1, "2" => 2} etc
   def convert_bundle_quantities_to_ints

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -19,6 +19,7 @@
           %br
           = select_tag('shows',
             options_from_collection_for_select(@all_shows, :id, :name_with_run_dates_short, @next_showdate.show.id), :multiple => true)
+          = submit_tag 'View', :id => 'advance_sales', :class => 'btn btn-primary'
           = submit_tag 'Download to Excel', :id => 'advanced_details', :download => true, :class => 'btn btn-primary'
 
 .container

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -9,7 +9,7 @@
           %br
           = select_tag('shows',
             options_from_collection_for_select(@all_shows, :id, :name_with_run_dates_short, @next_showdate.show.id), :multiple => true)
-          = submit_tag 'View', :id => 'advance_sales', :class => 'btn btn-primary'
+          = submit_tag 'Display on Screen', :id => 'advance_sales', :class => 'btn btn-primary'
           = submit_tag 'Download to Excel', :id => 'advanced_details', :download => true, :class => 'btn btn-primary'
 
 .container

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -2,14 +2,23 @@
   .container
     %h1 Advance Sales and Orders
     = form_tag advance_sales_reports_path, :method => :get do
-      %fieldset#advance_sales_report
+      %fieldset#view_advance_sales_report
         %legend Advance Sales
-        %p 
+        %p
           (Shift-click to select multiple productions)
           %br
-          = select_tag('shows', |
-            options_from_collection_for_select(@all_shows, :id, :name_with_run_dates_short, @next_showdate.show.id), :multiple => true) 
-          = submit_tag 'Go', :id => 'advance_sales', :class => 'btn btn-primary'
+          = select_tag('shows',
+            options_from_collection_for_select(@all_shows, :id, :name_with_run_dates_short, @next_showdate.show.id), :multiple => true)
+          = submit_tag 'View', :id => 'advance_sales', :class => 'btn btn-primary'
+    = form_tag advanced_details_reports_path, :method => :get do
+      %fieldset#download_advance_sales_report
+        %legend Advance Sales
+        %p
+          (Shift-click to select multiple productions)
+          %br
+          = select_tag('shows',
+            options_from_collection_for_select(@all_shows, :id, :name_with_run_dates_short, @next_showdate.show.id), :multiple => true)
+          = submit_tag 'Download to Excel', :id => 'advanced_details', :download => true, :class => 'btn btn-primary'
 
 .container
   = form_tag unfulfilled_orders_reports_path, :method => :get do
@@ -35,5 +44,5 @@
     Subscription Counts for
     - y = Time.this_season
     = select_tag('year', options_for_seasons(y-5, y+1), :onchange => "\$('#subscriber_stats').load('#{subscriber_details_reports_path}', 'id=' + \$('#year').val())" )
-  #subscriber_stats= render :partial => 'subscriptions', :object => @subscriptions, :locals => {:year => y} 
+  #subscriber_stats= render :partial => 'subscriptions', :object => @subscriptions, :locals => {:year => y}
 

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -1,18 +1,8 @@
 - if @next_showdate.kind_of?(Showdate)
   .container
     %h1 Advance Sales and Orders
-    = form_tag advance_sales_reports_path, :method => :get do
-      %fieldset#view_advance_sales_report
-        %legend Advance Sales
-        %p
-          (Shift-click to select multiple productions)
-          %br
-          = select_tag('shows',
-            options_from_collection_for_select(@all_shows, :id, :name_with_run_dates_short, @next_showdate.show.id), :multiple => true)
-          = submit_tag 'View', :id => 'advance_sales', :class => 'btn btn-primary'
-
     = form_tag advanced_details_reports_path, :method => :get do
-      %fieldset#download_advance_sales_report
+      %fieldset#advance_sales_report
         %legend Advance Sales
         %p
           (Shift-click to select multiple productions)

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -10,6 +10,7 @@
           = select_tag('shows',
             options_from_collection_for_select(@all_shows, :id, :name_with_run_dates_short, @next_showdate.show.id), :multiple => true)
           = submit_tag 'View', :id => 'advance_sales', :class => 'btn btn-primary'
+
     = form_tag advanced_details_reports_path, :method => :get do
       %fieldset#download_advance_sales_report
         %legend Advance Sales

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
         get :revenue_by_payment_method
         get :retail
         get :unfulfilled_orders
+        get :advanced_details
       end
     end
 


### PR DESCRIPTION
Now under /reports there should be two buttons for Advance Sales
  - Display on Screen (Renamed from the previous 'Go' button)
  - Download to Excel (new feature, generates and downloads a .csv of the desired report)

Preview: [https://tranquil-thicket-52105.herokuapp.com/reports](https://tranquil-thicket-52105.herokuapp.com/reports)

This feature follows this story: https://www.pivotaltracker.com/story/show/169792924