### PR TITLE
strong params changes for secret questoin with testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :test do
   gem 'rack-test'
   gem 'database_cleaner'
   gem 'email_spec'
+  gem 'faker'
   gem 'fake_stripe'
   gem 'poltergeist'
   gem 'rspec-json_expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       capybara
       sinatra
       webmock
+    faker (2.2.1)
+      i18n (>= 0.8)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.14.0)
@@ -405,6 +407,7 @@ DEPENDENCIES
   email_spec
   factory_bot_rails
   fake_stripe
+  faker
   faye-websocket
   figaro
   gibbon

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,8 +32,9 @@ class SessionsController < ApplicationController
 
   def create_from_secret
     create_session do |params|
+      permitted = secret_question_params
       @email = params[:email]
-      u = Customer.authenticate_from_secret_question(@email, params[:secret_question], params[:answer])
+      u = Customer.authenticate_from_secret_question(@email, permitted, params[:answer])
       if u.nil? || !u.errors.empty?
         note_failed_signin(@email, u)
         redirect_to (u.errors.has_key?(:no_secret_question) ? login_path : new_from_secret_session_path)
@@ -70,4 +71,9 @@ class SessionsController < ApplicationController
     Rails.logger.warn "Failed login for '#{attempted_username}' from #{request.remote_ip} at #{Time.current.utc}: #{flash[:alert]}"
   end
 
+  private
+
+  def secret_question_params
+    params.permit :secret_question
+  end
 end

--- a/app/models/customer/secret_question.rb
+++ b/app/models/customer/secret_question.rb
@@ -1,6 +1,4 @@
 class Customer < ActiveRecord::Base
-
-  attr_accessible :secret_question, :secret_answer
   
   validates_numericality_of(:secret_question,
     :greater_than_or_equal_to => 0,

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -115,5 +115,28 @@ describe SessionsController do
     it 'logs me out'                   do expect(controller).to receive(:logout_killing_session!); do_destroy end
     it 'redirects me to the home page' do do_destroy; expect(response).to be_redirect     end
   end
-  
+
+  describe "secret question params" do
+    let(:secret_question_params) {
+      {
+        email: "user84@yahoo.com",
+        secret_question: 5,
+        secret_answer: "yes",
+        answer: "yes",
+      }
+    }
+
+    context "when creating a secret question and secret answer with a mix of permitted and unpermitted params" do 
+      before :each do 
+        @user = Customer.create!(:first_name => "Fake", :last_name => "User", 
+                              :email => "user84@yahoo.com", :password => "test",
+                              :secret_question => 5, :secret_answer => "yes")
+        post :create_from_secret, secret_question_params
+      end
+
+      it "returns associated user" do
+        response.body == @user
+      end
+    end
+  end
 end


### PR DESCRIPTION
We removed model attributes that were `attr_accessible` and implemented strong parameters for the secret question.  

The model does not pass the params hash, and there is no mass assignment being done. There are already validations on the attributes. 