### PR TITLE
Reminder notes in options route ui changes

### DIFF
--- a/app/views/mailer/email_reminder.html.erb
+++ b/app/views/mailer/email_reminder.html.erb
@@ -1,0 +1,5 @@
+<div class="email_reminder">
+  <p class="general-reminder-email-notes">
+    <%= Option.general_reminder_email_notes %>
+  <p>
+</div>

--- a/app/views/options/index.html.haml
+++ b/app/views/options/index.html.haml
@@ -10,7 +10,7 @@
           venue_homepage_url |
           boxoffice_telephone |
           help_email |
-          box_office_email  | 
+          box_office_email  |
           send_birthday_reminders!days  |
           top_level_banner_text |
           privacy_policy_url |
@@ -18,13 +18,13 @@
       .form-row
         .col-md-4.text-right
           %label.col-form-label Season Start Date
-          = option_description_for(:season_start_month)   
+          = option_description_for(:season_start_month)
         .col-md-8
           .form-group.form-inline
             - season_start = Date.new(Time.current.year, Option.season_start_month, Option.season_start_day)
             = select_month season_start, {:prefix => 'option', :field_name => 'season_start_month'}, :class => 'form-control'
             = select_day   season_start, {:prefix => 'option', :field_name => 'season_start_day'}, :class => 'form-control'
-        
+
   .card.my-1
     .card-header.h3 Accepting Donations and Retail Sales Online
     .card-body
@@ -92,7 +92,7 @@
         allow_gift_tickets |
         allow_gift_subscriptions |
         precheckout_popup  |
-        terms_of_sale  |       
+        terms_of_sale  |
         checkout_notices |
         ) |
 
@@ -113,7 +113,7 @@
         classes_order_service_charge_description |
         classes_order_service_charge_account_code |
         ) |
- 
+
   .card.my-1
     .card-header.h3 Confirmation Emails
     .card-body
@@ -129,12 +129,21 @@
           = file_field_tag 'html_email_template', :accept => '.html', :hidden => 'hidden', :onchange => %q{$('#filename').html($('#html_email_template')[0].files[0].name + ' <i>(click Update Settings below to upload)</i>')}
           %label.col-form-label#filename (No file chosen)
 
-      = render_collection_of_options f, %w( |
-        general_confirmation_email_notes |
-        subscriber_confirmation_email_notes |
-        nonsubscriber_confirmation_email_notes |
-        subscription_purchase_email_notes |
-        ) |
+      - if Option.feature_enabled?('reminder_emails')
+        = render_collection_of_options f, %w( |
+          general_confirmation_email_notes |
+          general_reminder_email_notes |
+          subscriber_confirmation_email_notes |
+          nonsubscriber_confirmation_email_notes |
+          subscription_purchase_email_notes |
+          ) |
+      - else
+        = render_collection_of_options f, %w( |
+          general_confirmation_email_notes |
+          subscriber_confirmation_email_notes |
+          nonsubscriber_confirmation_email_notes |
+          subscription_purchase_email_notes |
+          ) |
 
   .card.my-1#configOptions
     .card-header

--- a/config/locales/en.option_descriptions.yml
+++ b/config/locales/en.option_descriptions.yml
@@ -8,7 +8,7 @@ en:
 
     advance_sales_cutoff: >
 
-      Default time that online sales close -- can be overridden for specific performances 
+      Default time that online sales close -- can be overridden for specific performances
       and specific ticket types.
 
     nearly_sold_out_threshold: >
@@ -33,7 +33,7 @@ en:
     allow_gift_tickets: >
 
       Whether customers can purchase individual tickets as a gift for
-      another customer. 
+      another customer.
 
     allow_gift_subscriptions: >
 
@@ -151,11 +151,11 @@ en:
       A value of 0 will suppress birthday notification emails completely.
 
     order_timeout: >
-      
+
       Number of minutes allowed to complete an order once tickets have been chosen.
       This number must be between 1 and 15 minutes and is enforced for all orders
       containing any ticket valid for a specific show date, whether
-      reserved seating or general admission.  
+      reserved seating or general admission.
 
     session_timeout: >
 
@@ -175,7 +175,7 @@ en:
 
       Banner text shown on Buy Subscriptions page to patrons who have
       purchased subscriptions for next season, whether or not they are
-      current subscribers.  It is placed inside a DIV with ID 
+      current subscribers.  It is placed inside a DIV with ID
       subscriptionBannerNextSeasonSubscriber and class storeBanner.
       The DIV can contain basic
       HTML tags but no JavaScript.
@@ -183,7 +183,7 @@ en:
     subscription_sales_banner_for_nonsubscribers: >
 
       Banner text shown on Buy Subscriptions page to NONSUBSCRIBERS.  It is
-      placed inside a DIV with ID subscriptionBannerNonsubscriber and class 
+      placed inside a DIV with ID subscriptionBannerNonsubscriber and class
       storeBanner.  The DIV can contain basic HTML tags
       but no JavaScript.
 
@@ -271,7 +271,7 @@ en:
 
     restrict_customer_email_to_domain: >
 
-      If nonblank, customers who self-signup must provide an email address ending 
+      If nonblank, customers who self-signup must provide an email address ending
       with this pattern (case-insensitive), for example "mycompany.org".  Useful if you
       are using Audience1st internally and only want members of your organization to be
       able to sign up as patrons; otherwise leave blank.  The restriction does not apply
@@ -298,7 +298,7 @@ en:
     display_email_opt_out: >
 
       Whether to display an email opt-out box when
-      customers edit their contact info.  
+      customers edit their contact info.
       NOTE: if set to "No", you MUST ensure that you
       provide your customers some other way to opt out of email in order to
       comply with CAN-SPAM laws.
@@ -313,7 +313,7 @@ en:
 
     subscription_order_service_charge: >
 
-      A flat fee (service charge) assessed on subscription orders only.  
+      A flat fee (service charge) assessed on subscription orders only.
       Leave blank or enter 0 for no charge.
 
     subscription_order_service_charge_description: >
@@ -327,12 +327,12 @@ en:
 
     regular_order_service_charge: >
 
-      A flat fee (service charge) assessed on regular (non-subscription) orders.  
+      A flat fee (service charge) assessed on regular (non-subscription) orders.
       Leave blank or enter 0 for no charge.
 
     regular_order_service_charge_description: >
 
-      A description that will appear on the order summary for regular 
+      A description that will appear on the order summary for regular
       (non-subscription) orders explaining this charge, for example, "Service Fee".
 
     regular_order_service_charge_account_code: >
@@ -371,6 +371,14 @@ en:
 
       General instructions to ALL CUSTOMERS that appear in order
       confirmation emails, for both single-ticket purchases and subscription
+      reservation confirmations. Use plain text (no HTML) and use a blank
+      line to separate paragraphs; text will be automatically word-wrapped
+      preserving your paragraph breaks.
+
+    general_reminder_email_notes: >
+
+      General instructions to ALL CUSTOMERS that appear in order
+      reminder emails, for both single-ticket purchases and subscription
       reservation confirmations. Use plain text (no HTML) and use a blank
       line to separate paragraphs; text will be automatically word-wrapped
       preserving your paragraph breaks.
@@ -459,4 +467,3 @@ en:
       https.  NOTE: Audience1st will also try to serve your
       favicon.ico from the same directory that contains the stylesheet; if
       no favicon.ico is found there, a generic one will be served.
-

--- a/db/migrate/20210425090446_add_reminder_emails_to_option.rb
+++ b/db/migrate/20210425090446_add_reminder_emails_to_option.rb
@@ -1,0 +1,5 @@
+class AddReminderEmailsToOption < ActiveRecord::Migration
+  def change
+    add_column :options, :general_reminder_email_notes, :text
+  end
+end

--- a/features/season_setup/change_options.feature
+++ b/features/season_setup/change_options.feature
@@ -5,7 +5,7 @@ Feature: change configuration options
   I want to see and edit the configuration options
 
 Background: logged in as admin
-  
+
   Given I am logged in as administrator
   And I visit the admin:settings page
   And I fill in all valid options
@@ -32,3 +32,16 @@ Scenario: invalid HTML email template because no placeholder
 
   When I upload the email template "invalid_template_no_placeholder.html"
   Then I should see "must contain exactly one occurrence of the placeholder"
+
+Scenario: reminder emails feature renders changeable General Reminder Email Notes in options
+  When I enable the reminder email feature
+  And I visit the admin:settings page
+  Then I should see "General Reminder Email Notes"
+  When I fill in "General Reminder Email Notes" with "This is an email reminder"
+  And I press "Update Settings"
+  Then the setting "General Reminder Email Notes" should be "This is an email reminder"
+
+Scenario: reminder emails feature iss disabled
+  When I disable the reminder email feature
+  And I visit the admin:settings page
+  Then I should not see "General Reminder Email Notes"

--- a/features/step_definitions/web_custom_steps.rb
+++ b/features/step_definitions/web_custom_steps.rb
@@ -114,7 +114,7 @@ end
 
 # Lets you write step def such as:
 # Then I should see the message for "customers.confirm_delete"
-Then /I should (not )?see the message for "(.*)"/ do |no,i18n_key| 
+Then /I should (not )?see the message for "(.*)"/ do |no,i18n_key|
   message = I18n.translate!(i18n_key)
   if no
     expect(page).not_to have_content(message)
@@ -133,3 +133,10 @@ Given /the URI "(.*)" is (not )?readable/ do |uri,no|
   end
 end
 
+When /^I enable the reminder email feature$/ do
+  enable_new_feature('reminder_emails')
+end
+
+When /^I disable the reminder email feature$/ do
+  disable_new_feature('reminder_emails')
+end


### PR DESCRIPTION
This PR achieves the UI change for the Reminder Email Notes. These are the changes in this PR



**features/season_setup/change_options.feature**: cucumber test to ensure that the "General Reminder Email Notes" actually gets rendered on the UI.


**app/views/mailer/email_reminder.html.erb**: new view that would eventually be rendered as the email reminder

**app/views/options/index.html.haml**: main point of change was "general_reminder_email_notes" on line 134. This renders the UI change.

**config/locales/en.option_descriptions.yml**: changed to account for help box on hover.

**db/migrate/20210425090446_add_reminder_emails_to_option.rb**: db migration change that modifies options schema to account for reminder email notes.

**features/season_setup/change_options.feature**: cucumber test to ensure that the "General Reminder Email Notes" actually gets rendered on the UI. This test also checks that the 'reminder_emails' feature enabling/disabling works appropriately.

**features/step_definitions/web_custom_steps.rb**: necessary change point to test that feature flag works appropriately


Here is a screenshot of the UI change in the options route. Specifically, the difference is the "General Reminder Email Notes"

![image](https://user-images.githubusercontent.com/35482884/116147905-2372dc00-a695-11eb-8be5-72ce30df3478.png)



A similar pull request for was made on our forked repo: https://github.com/abhinavDhulipala/audience1st/pull/35

This is also deployed on a staging app available at https://calvisitor.herokuapp.com/options