### PR TITLE
Reminder Options for Create/Edit Show Views 

### DIFF
--- a/app/controllers/shows_controller.rb
+++ b/app/controllers/shows_controller.rb
@@ -64,6 +64,7 @@ class ShowsController < ApplicationController
   # migrating from protected attr to strong param
   # standard found here: https://www.fastruby.io/blog/rails/upgrades/strong-parameters-migration-guide.html
   private
+
   def season_new_params
     params.permit :season
     params.fetch :season, Time.this_season
@@ -71,13 +72,13 @@ class ShowsController < ApplicationController
 
   def show_params
     permitted = params.require(:show).permit(:name, :event_type,
-                                             :season,
                                              :listing_date,
                                              :landing_page_url,
                                              :description,
                                              :patron_notes,
                                              :sold_out_dropdown_message,
-                                             :sold_out_customer_info)
+                                             :sold_out_customer_info,
+                                             :reminder_type)
     permitted
   end
 end

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -3,6 +3,12 @@ class Show < ActiveRecord::Base
   REGULAR_SHOW = 'Regular Show'
   TYPES = [REGULAR_SHOW, 'Special Event', 'Class', 'Subscription']
 
+  REMINDERS = ['Never', 
+              '12 hours before curtain time', 
+              '24 hours before curtain time', 
+              '36 hours before curtain time', 
+              '48 hours before curtain time']
+
   has_many :showdates, -> { order('thedate') }, :dependent => :destroy
   has_one :latest_showdate, -> { order('thedate DESC') }, :class_name => 'Showdate'
   has_many :vouchers, -> { joins(:vouchertype).merge(Voucher.finalized).merge(Vouchertype.seat_vouchertypes) }, :through => :showdates
@@ -12,6 +18,7 @@ class Show < ActiveRecord::Base
   validates_presence_of :season
   validates :season, :presence => true, :numericality => {:greater_than_or_equal_to => 1900}
   validates_inclusion_of :event_type, :in => Show::TYPES
+  validates_inclusion_of :reminder_type, :in => Show::REMINDERS
   validates_length_of :name,                   :within => 1..255
   validates_length_of :description,            :maximum => 255
   validates_length_of :landing_page_url,       :maximum => 255

--- a/app/views/shows/_form.html.haml
+++ b/app/views/shows/_form.html.haml
@@ -44,6 +44,13 @@
       %label.col-form-label{:for => :show_sold_out_customer_info} If show is sold out, information for patron
       = f.text_field 'sold_out_customer_info', :maxlength => 255, :class => 'form-control'
 
+  - if Option.feature_enabled?('reminder_emails')
+    .form-row
+      .col-md-4.form-group
+        = popup_help_for :show_reminder_email
+        %label.col-form-label{:for=>:show_reminder_type} Send reminder email to ticket holders
+        = f.select 'reminder_type', Show::REMINDERS, {}, {:class => 'form-control'}
+
   .form-row
     = f.submit :class => 'btn btn-success mx-2'
     = link_to 'Back to List of Shows', shows_path(:season => @show.season), :class => 'btn btn-secondary'

--- a/config/locales/en.popup_help.yml
+++ b/config/locales/en.popup_help.yml
@@ -108,6 +108,11 @@ en:
 
     # Editing shows and showdates
 
+    show_reminder_email: >
+
+      Schedule a reminder email that will be automatically sent out to ticket holders 
+      at a given time before the event.
+
     show_season: >
 
       Which season the show is in.  Cannot be changed once the show is created.

--- a/db/migrate/20210415011621_add_reminder_to_shows.rb
+++ b/db/migrate/20210415011621_add_reminder_to_shows.rb
@@ -1,0 +1,5 @@
+class AddReminderToShows < ActiveRecord::Migration
+  def change
+    add_column :shows, :reminder_type, :string, :null => false, :default => Show::REMINDERS.first
+  end
+end

--- a/db/migrate/20210415014347_add_reminder_to_options.rb
+++ b/db/migrate/20210415014347_add_reminder_to_options.rb
@@ -1,0 +1,5 @@
+class AddReminderToOptions < ActiveRecord::Migration
+  def change
+  	add_column :options, :reminder_emails, :string, :default => "Never"
+  end
+end

--- a/db/migrate/20210418205013_remove_reminder_from_shows.rb
+++ b/db/migrate/20210418205013_remove_reminder_from_shows.rb
@@ -1,0 +1,5 @@
+class RemoveReminderFromShows < ActiveRecord::Migration
+  def change
+  	remove_column :shows, :reminder_type, :string, :limit => 255, :default => "Never", :null => false
+  end
+end

--- a/db/migrate/20210418205452_add_reminder_type_to_shows.rb
+++ b/db/migrate/20210418205452_add_reminder_type_to_shows.rb
@@ -1,0 +1,10 @@
+# This migration is was needed because we found that the `reminder_types` column was duplicated
+# due to adding a "limig: 255" field in one migration, but not including in an updated migration later
+# so a new migration wasm ade to try and remove that duplicate column but it removed both
+# this migration is to put the column back
+
+class AddReminderTypeToShows < ActiveRecord::Migration
+  def change
+    add_column :shows, :reminder_type, :string, :null => false, :default => Show::REMINDERS.first
+  end
+end

--- a/features/season_setup/setup_show.feature
+++ b/features/season_setup/setup_show.feature
@@ -10,12 +10,14 @@ Background:
 
 Scenario: Setup new show
 
-  When I go to the New Show page
+  When I enable the reminder email feature
+  And I go to the New Show page
   And I fill in the "show" fields as follows:
   | field                                                          | value                        |
   | Show Name                                                      | Fiddler on the Roof          |
   | List starting                                                  | select date "2010-03-11"     |
   | Event type                                                     | select "Regular Show"        |
+  | Send reminder email to ticket holders                          | select "12 hours before curtain time"            |
   | Landing page URL (optional)                                    | http://mytheatre.com/fiddler |
   | Description (optional)                                         | A classic                    |
   | Special notes to patron (in confirmation email); blank if none | Enjoy                        |

--- a/features/step_definitions/web_custom_steps.rb
+++ b/features/step_definitions/web_custom_steps.rb
@@ -133,3 +133,6 @@ Given /the URI "(.*)" is (not )?readable/ do |uri,no|
   end
 end
 
+When /^I enable the reminder email feature$/ do
+  enable_new_feature('reminder_emails')
+end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -203,4 +203,3 @@ Then /^show me the page and debug$/ do
   require "rubygems"; require "byebug"; byebug
   1 #intentionally force debugger context in this method 
 end
-

--- a/features/support/feature_flag_helpers.rb
+++ b/features/support/feature_flag_helpers.rb
@@ -1,0 +1,11 @@
+module FeatureFlagHelpers
+  def enable_new_feature(feature_name)
+    Option.enable_feature!(feature_name)
+  end
+
+  def disable_new_feature(feature_name)
+    Option.disable_feature!(feature_name)
+  end
+end
+
+World(FeatureFlagHelpers)

--- a/spec/controllers/shows_controller_spec.rb
+++ b/spec/controllers/shows_controller_spec.rb
@@ -28,7 +28,8 @@ describe ShowsController do
           name: "some show",
           description: "desc",
           bad_param: "bad",
-          listing_date: Date.today
+          listing_date: Date.today,
+          reminder_type: "12 hours before curtain time"
         }
       }
     }
@@ -46,15 +47,14 @@ describe ShowsController do
       end
       it "create will not set value of unpermitted param" do
         expect(response).to redirect_to(edit_show_path( id:1 ))
-        
         expect( @post_show.attributes.has_key? "bad_param").to eq(false)
       end
       it "create will set the value of permitted params" do
         expect(response).to redirect_to(edit_show_path( id:1 ))
-        
         expect( @post_show.name ).to eq("some show")
         expect( @post_show.description ).to eq("desc")
         expect( @post_show.listing_date ).to eq(Date.today)
+        expect( @post_show.reminder_type ).to eq("12 hours before curtain time")
       end
     end
 
@@ -82,6 +82,16 @@ describe ShowsController do
 
       @s.reload
       expect(@s.description).to eq("updated description")
+    end
+
+    it "should update the reminder type" do
+      @s = create(:show, :name => "valid name")
+      expect(@s.reminder_type).to eq("Never")
+      response = post :update, :id => @s.id, :show => { :reminder_type => "24 hours before curtain time" }
+      expect(response).to redirect_to edit_show_path(@s)
+
+      @s.reload
+      expect(@s.reminder_type).to eq("24 hours before curtain time")
     end
   end
 


### PR DESCRIPTION
@armandofox 
**NOTE**: While Travis passes on our fork's main branch, it will most likely fail in this PR to the Golden Repo due to trouble detecting the `tenant_names` environment variable across forks.

This PR has been rebased with the GR's latest changes. This PR was originally intended for just the UI changes in the Create/Edit shows views to include reminder options for campaigns. However, it may include previous tickets from past iterations that were never merged into the GR.

Development Notes for Create and Edit Shows UI:
- Made changes in:
    - **app/views/shows/_form.html.haml**
        - Edited partial to include the dropdown menu for both the “Add new show” and “Edit existing show” page views
    - **app/models/show.rb**
        - Added validation that should check that the reminder type is valid/in the enumerable defined as “REMINDERS”
    - **config/locales/en.popup_help.yml**
        - Added an environment variable (I think) that stores the popup message for the dropdown menu
    - **features/season_setup/setup_show.feature**
        - Added a line to this cucumber test that tests a user selecting an option from the new dropdown menu
       
Some more PR notes. Files and changes also included:
- the migration file for the new `reminder_type` column in the `shows` table, 
- the migration file for the new feature option `reminder_emails` in the `options` table
- a feature flag that wraps the new UI for this feature
- reminder types added as a strong parameter in the `shows` controller
- updated Cucumber tests and RSpec tests

Here are screenshots of the final changes:
- for the `.../shows/new/...` route

<img width="907" alt="Screen Shot 2021-04-14 at 7 21 15 PM" src="https://user-images.githubusercontent.com/24798899/114804743-a8d1c480-9d56-11eb-9529-bae6e545d0da.png">

- for the `.../shows/{id}/edit` route

<img width="911" alt="Screen Shot 2021-04-14 at 7 23 16 PM" src="https://user-images.githubusercontent.com/24798899/114804869-e1719e00-9d56-11eb-91ee-f273e3e17a6f.png">

