### PR TITLE
[Finishes #187386170] Remove quick donation banner and explanation fields

### DIFF
--- a/app/views/options/index.html.haml
+++ b/app/views/options/index.html.haml
@@ -36,8 +36,6 @@
         default_retail_account_code |
         default_donation_account_code |
         default_donation_account_code_with_subscriptions |
-        quick_donation_banner |
-        quick_donation_explanation |
         quick_donation_redirect |
         donation_ack_from |
         ) |

--- a/config/locales/en.option_descriptions.yml
+++ b/config/locales/en.option_descriptions.yml
@@ -107,17 +107,6 @@ en:
       Auto-generated confirmation emails for online donations will appear to be
       signed by this person.  Example: "Bob Jones, Development Chair"
 
-    quick_donation_banner: >
-
-      The banner text that appears at the top of the "donate instantly"
-      (donate by credit card without logging in) page.
-
-    quick_donation_explanation: >
-
-      Explanatory text that appears on the "donate instantly" page.  Basic
-      HTML is allowed.  For example, you could direct patrons who wish to
-      donate by check to download a form or call the development office.
-
     quick_donation_redirect: >
 
       If not blank, the absolute URL to which the patron is redirected after

--- a/db/migrate/20240417020007_remove_quick_donation_fields_from_options.rb
+++ b/db/migrate/20240417020007_remove_quick_donation_fields_from_options.rb
@@ -1,0 +1,4 @@
+class RemoveQuickDonationFieldsFromOptions < ActiveRecord::Migration
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20240225093946) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 20240417020007) do
 
   create_table "account_codes", force: :cascade do |t|
     t.string "name",            limit: 255, default: "", null: false
@@ -68,14 +65,14 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.integer  "ticket_sales_import_id"
   end
 
-  add_index "customers", ["ticket_sales_import_id"], name: "index_customers_on_ticket_sales_import_id", using: :btree
+  add_index "customers", ["ticket_sales_import_id"], name: "index_customers_on_ticket_sales_import_id"
 
   create_table "customers_labels", id: false, force: :cascade do |t|
     t.integer "customer_id"
     t.integer "label_id"
   end
 
-  add_index "customers_labels", ["customer_id", "label_id"], name: "index_customers_labels_on_customer_id_and_label_id", unique: true, using: :btree
+  add_index "customers_labels", ["customer_id", "label_id"], name: "index_customers_labels_on_customer_id_and_label_id", unique: true
 
   create_table "items", force: :cascade do |t|
     t.integer  "vouchertype_id",                 default: 0,          null: false
@@ -99,15 +96,15 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.datetime "sold_on"
   end
 
-  add_index "items", ["account_code_id"], name: "index_items_on_account_code_id", using: :btree
-  add_index "items", ["bundle_id"], name: "index_items_on_bundle_id", using: :btree
-  add_index "items", ["customer_id"], name: "index_items_on_customer_id", using: :btree
-  add_index "items", ["finalized"], name: "index_items_on_finalized", using: :btree
-  add_index "items", ["order_id"], name: "index_items_on_order_id", using: :btree
-  add_index "items", ["processed_by_id"], name: "index_items_on_processed_by_id", using: :btree
-  add_index "items", ["seat"], name: "index_items_on_seat", using: :btree
-  add_index "items", ["showdate_id"], name: "index_items_on_showdate_id", using: :btree
-  add_index "items", ["vouchertype_id"], name: "index_items_on_vouchertype_id", using: :btree
+  add_index "items", ["account_code_id"], name: "index_items_on_account_code_id"
+  add_index "items", ["bundle_id"], name: "index_items_on_bundle_id"
+  add_index "items", ["customer_id"], name: "index_items_on_customer_id"
+  add_index "items", ["finalized"], name: "index_items_on_finalized"
+  add_index "items", ["order_id"], name: "index_items_on_order_id"
+  add_index "items", ["processed_by_id"], name: "index_items_on_processed_by_id"
+  add_index "items", ["seat"], name: "index_items_on_seat"
+  add_index "items", ["showdate_id"], name: "index_items_on_showdate_id"
+  add_index "items", ["vouchertype_id"], name: "index_items_on_vouchertype_id"
 
   create_table "labels", force: :cascade do |t|
     t.string "name", limit: 255
@@ -225,11 +222,11 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.text     "from_import"
   end
 
-  add_index "orders", ["customer_id"], name: "index_orders_on_customer_id", using: :btree
-  add_index "orders", ["external_key"], name: "index_orders_on_external_key", using: :btree
-  add_index "orders", ["processed_by_id"], name: "index_orders_on_processed_by_id", using: :btree
-  add_index "orders", ["purchaser_id"], name: "index_orders_on_purchaser_id", using: :btree
-  add_index "orders", ["ticket_sales_import_id"], name: "index_orders_on_ticket_sales_import_id", using: :btree
+  add_index "orders", ["customer_id"], name: "index_orders_on_customer_id"
+  add_index "orders", ["external_key"], name: "index_orders_on_external_key"
+  add_index "orders", ["processed_by_id"], name: "index_orders_on_processed_by_id"
+  add_index "orders", ["purchaser_id"], name: "index_orders_on_purchaser_id"
+  add_index "orders", ["ticket_sales_import_id"], name: "index_orders_on_ticket_sales_import_id"
 
   create_table "seating_zones", force: :cascade do |t|
     t.string  "name"
@@ -264,8 +261,8 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.string   "house_seats",         limit: 8192
   end
 
-  add_index "showdates", ["seatmap_id"], name: "index_showdates_on_seatmap_id", using: :btree
-  add_index "showdates", ["show_id"], name: "index_showdates_on_show_id", using: :btree
+  add_index "showdates", ["seatmap_id"], name: "index_showdates_on_seatmap_id"
+  add_index "showdates", ["show_id"], name: "index_showdates_on_show_id"
 
   create_table "shows", force: :cascade do |t|
     t.string   "name",                      limit: 255
@@ -295,7 +292,7 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.datetime "created_at"
   end
 
-  add_index "ticket_sales_imports", ["processed_by_id"], name: "index_ticket_sales_imports_on_processed_by_id", using: :btree
+  add_index "ticket_sales_imports", ["processed_by_id"], name: "index_ticket_sales_imports_on_processed_by_id"
 
   create_table "txns", force: :cascade do |t|
     t.integer  "customer_id",                default: 1,   null: false
@@ -311,12 +308,12 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.string   "txn_type",       limit: 255
   end
 
-  add_index "txns", ["customer_id"], name: "index_txns_on_customer_id", using: :btree
-  add_index "txns", ["entered_by_id"], name: "index_txns_on_entered_by_id", using: :btree
-  add_index "txns", ["order_id"], name: "index_txns_on_order_id", using: :btree
-  add_index "txns", ["show_id"], name: "index_txns_on_show_id", using: :btree
-  add_index "txns", ["showdate_id"], name: "index_txns_on_showdate_id", using: :btree
-  add_index "txns", ["voucher_id"], name: "index_txns_on_voucher_id", using: :btree
+  add_index "txns", ["customer_id"], name: "index_txns_on_customer_id"
+  add_index "txns", ["entered_by_id"], name: "index_txns_on_entered_by_id"
+  add_index "txns", ["order_id"], name: "index_txns_on_order_id"
+  add_index "txns", ["show_id"], name: "index_txns_on_show_id"
+  add_index "txns", ["showdate_id"], name: "index_txns_on_showdate_id"
+  add_index "txns", ["voucher_id"], name: "index_txns_on_voucher_id"
 
   create_table "valid_vouchers", force: :cascade do |t|
     t.integer  "showdate_id"
@@ -331,8 +328,8 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.integer  "max_sales_per_txn",               default: 100000
   end
 
-  add_index "valid_vouchers", ["showdate_id"], name: "index_valid_vouchers_on_showdate_id", using: :btree
-  add_index "valid_vouchers", ["vouchertype_id"], name: "index_valid_vouchers_on_vouchertype_id", using: :btree
+  add_index "valid_vouchers", ["showdate_id"], name: "index_valid_vouchers_on_showdate_id"
+  add_index "valid_vouchers", ["vouchertype_id"], name: "index_valid_vouchers_on_vouchertype_id"
 
   create_table "vouchertypes", force: :cascade do |t|
     t.string   "name",                limit: 255
@@ -352,6 +349,6 @@ ActiveRecord::Schema.define(version: 20240225093946) do
     t.integer  "seating_zone_id"
   end
 
-  add_index "vouchertypes", ["account_code_id"], name: "index_vouchertypes_on_account_code_id", using: :btree
+  add_index "vouchertypes", ["account_code_id"], name: "index_vouchertypes_on_account_code_id"
 
 end


### PR DESCRIPTION
**This branch handles the following:**
- Create migration file to remove quick_donation_banner and quick_donation_explanation fields from the database schema.
- remove from options collection in view app/views/options/index.html.haml
- remove from option descriptions config/locales/en.option_descriptions.yml
- remove from options table db/schema.rb